### PR TITLE
Fixed support for pf2e npcs and familiars

### DIFF
--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -14,19 +14,19 @@ class TokenInfoIcons {
           ac = (isNaN(parseInt(actor.data.data.attributes.ac.value)) || parseInt(actor.data.data.attributes.ac.value) === 0) ? 10 : parseInt(actor.data.data.attributes.ac.value);
         }
 
-		let perceptionTitle = "Passive Perception";
+        let perceptionTitle = "Passive Perception";
         let perception = 10;
         if (game.world.system === "pf1") {
             perception = actor.data.data.skills.per.mod
-			perceptionTitle = "Perception Mod";
+            perceptionTitle = "Perception Mod";
         } else if (game.world.system === "pf2e") {
-			if (actor.data.type === "npc" || actor.data.type === "familiar") {
-				perception = perception + actor.data.data.attributes.perception.value;
-			}else {
-				const proficiency = actor.data.data.attributes.perception.rank ? actor.data.data.attributes.perception.rank * 2 + actor.data.data.details.level.value : 0;
-				perception = perception + actor.data.data.abilities[actor.data.data.attributes.perception.ability].mod + proficiency + actor.data.data.attributes.perception.item;
-			}
-			perceptionTitle = "Perception DC";
+            if (actor.data.type === "npc" || actor.data.type === "familiar") {
+                perception = perception + actor.data.data.attributes.perception.value;
+            }else {
+                const proficiency = actor.data.data.attributes.perception.rank ? actor.data.data.attributes.perception.rank * 2 + actor.data.data.details.level.value : 0;
+                perception = perception + actor.data.data.abilities[actor.data.data.attributes.perception.ability].mod + proficiency + actor.data.data.attributes.perception.item;
+            }
+            perceptionTitle = "Perception DC";
         } else {
             perception = actor.data.data.skills.prc.passive;
         }
@@ -36,15 +36,15 @@ class TokenInfoIcons {
         let speed = "";
 
         if (game.world.system === "pf2e") {
-			if (actor.data.type === "npc") {				
-				speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i><span style="font-size: 0.65em;"> ' + actor.data.data.attributes.speed.value + '</span></span>';
-			} else if (actor.data.type === "familiar") {
-				// Familiars seem to get either 25 ft. land or water speed
-				// It can be modified by other abilities but they will be revising these later so this will likely change
-				speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i> 25</span>';
-			} else {
-				speed = '<span style="white-space: pre;" title="Land"><i class="fas fa-walking"></i> ' + actor.data.data.attributes.speed.total + '</span>';
-			}
+            if (actor.data.type === "npc") {				
+                speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i><span style="font-size: 0.65em;"> ' + actor.data.data.attributes.speed.value + '</span></span>';
+            } else if (actor.data.type === "familiar") {
+                // Familiars seem to get either 25 ft. land or water speed
+                // It can be modified by other abilities but they will be revising these later so this will likely change
+                speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i> 25</span>';
+            } else {
+                speed = '<span style="white-space: pre;" title="Land"><i class="fas fa-walking"></i> ' + actor.data.data.attributes.speed.total + '</span>';
+            }
         } else if (game.world.system === "pf1") {
             speed = '<span style="white-space: pre;" title="Land"><i class="fas fa-walking"></i> ' + actor.data.data.attributes.speed.land.total + '</span>';
         } else {

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -14,12 +14,19 @@ class TokenInfoIcons {
           ac = (isNaN(parseInt(actor.data.data.attributes.ac.value)) || parseInt(actor.data.data.attributes.ac.value) === 0) ? 10 : parseInt(actor.data.data.attributes.ac.value);
         }
 
+		let perceptionTitle = "Passive Perception";
         let perception = 10;
         if (game.world.system === "pf1") {
             perception = actor.data.data.skills.per.mod
+			perceptionTitle = "Perception Mod";
         } else if (game.world.system === "pf2e") {
-            const proficiency = actor.data.data.attributes.perception.rank ? actor.data.data.attributes.perception.rank * 2 + actor.data.data.details.level.value : 0;
-            perception = perception + actor.data.data.abilities[actor.data.data.attributes.perception.ability].mod + proficiency + actor.data.data.attributes.perception.item;
+			if (actor.data.type === "npc" || actor.data.type === "familiar") {
+				perception = perception + actor.data.data.attributes.perception.value;
+			}else {
+				const proficiency = actor.data.data.attributes.perception.rank ? actor.data.data.attributes.perception.rank * 2 + actor.data.data.details.level.value : 0;
+				perception = perception + actor.data.data.abilities[actor.data.data.attributes.perception.ability].mod + proficiency + actor.data.data.attributes.perception.item;
+			}
+			perceptionTitle = "Perception DC";
         } else {
             perception = actor.data.data.skills.prc.passive;
         }
@@ -29,7 +36,15 @@ class TokenInfoIcons {
         let speed = "";
 
         if (game.world.system === "pf2e") {
-            speed = '<span style="white-space: pre;" title="Land"><i class="fas fa-walking"></i> ' + actor.data.data.attributes.speed.total + '</span>';
+			if (actor.data.type === "npc") {				
+				speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i><span style="font-size: 0.65em;"> ' + actor.data.data.attributes.speed.value + '</span></span>';
+			} else if (actor.data.type === "familiar") {
+				// Familiars seem to get either 25 ft. land or water speed
+				// It can be modified by other abilities but they will be revising these later so this will likely change
+				speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i> 25</span>';
+			} else {
+				speed = '<span style="white-space: pre;" title="Land"><i class="fas fa-walking"></i> ' + actor.data.data.attributes.speed.total + '</span>';
+			}
         } else if (game.world.system === "pf1") {
             speed = '<span style="white-space: pre;" title="Land"><i class="fas fa-walking"></i> ' + actor.data.data.attributes.speed.land.total + '</span>';
         } else {
@@ -44,7 +59,7 @@ class TokenInfoIcons {
 
         let position = game.settings.get("token-info-icons", "position");
 
-        let buttons = $('<div class="col token-info-column-' + position + '"><div class="control-icon token-info-icon">' + speed + '</div><div class="control-icon token-info-icon" title="Armor Class: ' + ac + '"><i class="fas fa-shield-alt"></i> ' + ac + '</div><div class="control-icon token-info-icon" title="Passive Perception: ' + perception + '"><i class="fas fa-eye"></i> ' + perception + '</div></div>');
+        let buttons = $('<div class="col token-info-column-' + position + '"><div class="control-icon token-info-icon">' + speed + '</div><div class="control-icon token-info-icon" title="Armor Class: ' + ac + '"><i class="fas fa-shield-alt"></i> ' + ac + '</div><div class="control-icon token-info-icon" title="' + perceptionTitle + ': ' + perception + '"><i class="fas fa-eye"></i> ' + perception + '</div></div>');
 
         html.find('.col.left').wrap(newdiv);
         html.find('.col.left').before(buttons);


### PR DESCRIPTION
The pf2e team says they are continuing to revise the NPC sheets and the familiar sheets badly need updating, so I expect these to continue to change. For now, this fixes the speed being shown as "undefined" for npcs and for the correct perception DC value to be displayed (which seems to be stored differently for npcs).

The token info icons wouldn't even display for familiar tokens due to how their data was organized.