### PR TITLE
Add passive senses to displayed info

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.idea/
 module-releases_template.txt

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple module that displays Speed, AC, and Passive Perception on Tokens for the 
 To install a module, follow these instructions:
 
 1. Start FVTT and browse to the Game Modules tab in the Configuration and Setup menu
-2. Select the Install Module button and enter the following URL: https://raw.githubusercontent.com/johnmartel/fvtt-token-info-icons/master/module.json
+2. Select the Install Module button and enter the following URL: https://raw.githubusercontent.com/jopeek/fvtt-token-info-icons/master/module.json
 3. Click Install and wait for installation to complete 
 
 ### Feedback

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple module that displays Speed, AC, and Passive Perception on Tokens for the 
 To install a module, follow these instructions:
 
 1. Start FVTT and browse to the Game Modules tab in the Configuration and Setup menu
-2. Select the Install Module button and enter the following URL: https://raw.githubusercontent.com/jopeek/fvtt-token-info-icons/master/module.json
+2. Select the Install Module button and enter the following URL: https://raw.githubusercontent.com/johnmartel/fvtt-token-info-icons/master/module.json
 3. Click Install and wait for installation to complete 
 
 ### Feedback

--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
     "styles": [
         "/css/token-info-icons.css"
     ],
-    "url": "https://github.com/johnmartel/fvtt-token-info-icons",
-    "manifest": "https://raw.githubusercontent.com/johnmartel/fvtt-token-info-icons/master/module.json",
-    "download": "https://github.com/johnmartel/fvtt-token-info-icons/archive/master.zip"
+    "url": "https://github.com/jopeek/fvtt-token-info-icons",
+    "manifest": "https://raw.githubusercontent.com/jopeek/fvtt-token-info-icons/master/module.json",
+    "download": "https://github.com/jopeek/fvtt-token-info-icons/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
     "styles": [
         "/css/token-info-icons.css"
     ],
-    "url": "https://github.com/jopeek/fvtt-token-info-icons",
-    "manifest": "https://raw.githubusercontent.com/jopeek/fvtt-token-info-icons/master/module.json",
-    "download": "https://github.com/jopeek/fvtt-token-info-icons/archive/master.zip"
+    "url": "https://github.com/johnmartel/fvtt-token-info-icons",
+    "manifest": "https://raw.githubusercontent.com/johnmartel/fvtt-token-info-icons/master/module.json",
+    "download": "https://github.com/johnmartel/fvtt-token-info-icons/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -1,15 +1,23 @@
 {
-	"name": "token-info-icons",
-	"title": "Token Info Icons",
-	"description": "Simple module that displays Speed, AC, and Passive Perception on Tokens for the GM or optionally players.",
-	"version": "2.1.3",
-	"minimumCoreVersion": "0.7.7",
-	"compatibleCoreVersion": "0.7.7",
-	"author": "Jan Ole Peek (ChalkOne)",
-	"systems": ["dnd5e", "pf2e", "pf1"],
-	"scripts": ["/token-info-icons.js"],
-	"styles": ["/css/token-info-icons.css"],
-	"url": "https://github.com/jopeek/fvtt-token-info-icons",
-	"manifest": "https://raw.githubusercontent.com/jopeek/fvtt-token-info-icons/master/module.json",
-	"download": "https://github.com/jopeek/fvtt-token-info-icons/archive/master.zip"
+    "name": "token-info-icons",
+    "title": "Token Info Icons",
+    "description": "Simple module that displays Speed, AC, and Passive Perception on Tokens for the GM or optionally players.",
+    "version": "2.1.3",
+    "minimumCoreVersion": "0.7.7",
+    "compatibleCoreVersion": "0.7.7",
+    "author": "Jan Ole Peek (ChalkOne)",
+    "systems": [
+        "dnd5e",
+        "pf2e",
+        "pf1"
+    ],
+    "scripts": [
+        "/token-info-icons.js"
+    ],
+    "styles": [
+        "/css/token-info-icons.css"
+    ],
+    "url": "https://github.com/jopeek/fvtt-token-info-icons",
+    "manifest": "https://raw.githubusercontent.com/jopeek/fvtt-token-info-icons/master/module.json",
+    "download": "https://github.com/jopeek/fvtt-token-info-icons/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
     "description": "Simple module that displays Speed, AC, and Passive Perception on Tokens for the GM or optionally players.",
     "version": "2.1.3",
     "minimumCoreVersion": "0.7.7",
-    "compatibleCoreVersion": "0.7.7",
+    "compatibleCoreVersion": "0.7.8",
     "author": "Jan Ole Peek (ChalkOne)",
     "systems": [
         "dnd5e",

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -1,3 +1,8 @@
+const MODULE_NAME = 'token-info-icons';
+const GMONLY_MODULE_SETTING = 'gmOnly';
+const ALL_PASSIVE_SENSES_MODULE_SETTING = 'allPassiveSenses';
+const POSITION_MODULE_SETTING = 'position';
+
 class TokenInfoIcons {
     static async addTokenInfoButtons(app, html, data) {
         let actor = canvas.tokens.get(data._id).actor;

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -61,7 +61,7 @@ class TokenInfoIcons {
 
         let position = game.settings.get(MODULE_NAME, POSITION_MODULE_SETTING);
 
-        let defaultButtons = '<div class="col token-info-column-' + position + '"><div class="control-icon token-info-icon">' + speed + '</div><div class="control-icon token-info-icon" title="Armor Class: ' + ac + '"><i class="fas fa-shield-alt"></i> ' + ac + '</div><div class="control-icon token-info-icon" title="Passive Perception: ' + perception + '"><i class="fas fa-eye"></i> ' + perception + '</div></div>'
+        let defaultButtons = '<div class="control-icon token-info-icon">' + speed + '</div><div class="control-icon token-info-icon" title="Armor Class: ' + ac + '"><i class="fas fa-shield-alt"></i> ' + ac + '</div><div class="control-icon token-info-icon" title="Passive Perception: ' + perception + '"><i class="fas fa-eye"></i> ' + perception + '</div>'
 
         let passiveSensesButtons = '';
         if (!['pf2e', 'pf1'].includes(game.world.system) && game.settings.get(MODULE_NAME, ALL_PASSIVE_SENSES_MODULE_SETTING)) {
@@ -75,7 +75,7 @@ class TokenInfoIcons {
             passiveSensesButtons = `${passiveInvestigationButton}${passiveInsightButton}${passiveStealthButton}`;
         }
 
-        let buttons = $(`${defaultButtons}${passiveSensesButtons}`);
+        let buttons = $(`<div class="col token-info-column-${position}">${defaultButtons}${passiveSensesButtons}</div>`);
 
         html.find('.col.left').wrap(newdiv);
         html.find('.col.left').before(buttons);

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -24,7 +24,7 @@ class TokenInfoIcons {
         } else if (game.world.system === "pf2e") {
             if (actor.data.type === "npc" || actor.data.type === "familiar") {
                 perception = perception + actor.data.data.attributes.perception.value;
-            }else {
+            } else {
                 const proficiency = actor.data.data.attributes.perception.rank ? actor.data.data.attributes.perception.rank * 2 + actor.data.data.details.level.value : 0;
                 perception = perception + actor.data.data.abilities[actor.data.data.attributes.perception.ability].mod + proficiency + actor.data.data.attributes.perception.item;
             }
@@ -65,9 +65,9 @@ class TokenInfoIcons {
 
         let passiveSensesButtons = '';
         if (!['pf2e', 'pf1'].includes(game.world.system) && game.settings.get(MODULE_NAME, ALL_PASSIVE_SENSES_MODULE_SETTING)) {
-            const investigation =  actor.data.data.skills.inv.passive;
-            const insight =  actor.data.data.skills.ins.passive;
-            const stealth =  actor.data.data.skills.ste.passive;
+            const investigation = actor.data.data.skills.inv.passive;
+            const insight = actor.data.data.skills.ins.passive;
+            const stealth = actor.data.data.skills.ste.passive;
 
             const passiveInvestigationButton = `<div class="control-icon token-info-icon" title="Passive Investigation: ${investigation}"><i class="fas fa-search"></i>${investigation}</div></div>`;
             const passiveInsightButton = `<div class="control-icon token-info-icon" title="Passive Insight: ${insight}"><i class="fas fa-lightbulb"></i>${insight}</div></div>`;

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -33,7 +33,7 @@ class TokenInfoIcons {
         let speed = "";
 
         if (game.world.system === "pf2e") {
-            if (actor.data.type === "npc") {				
+            if (actor.data.type === "npc") {
                 speed = '<span style="white-space: pre;" title="Speed"><i class="fas fa-walking"></i><span style="font-size: 0.65em;"> ' + actor.data.data.attributes.speed.value + '</span></span>';
             } else if (actor.data.type === "familiar") {
                 // Familiars seem to get either 25 ft. land or water speed
@@ -54,9 +54,23 @@ class TokenInfoIcons {
 
         let newdiv = '<div class="token-info-container">';
 
-        let position = game.settings.get("token-info-icons", "position");
+        let position = game.settings.get(MODULE_NAME, POSITION_MODULE_SETTING);
 
-        let buttons = $('<div class="col token-info-column-' + position + '"><div class="control-icon token-info-icon">' + speed + '</div><div class="control-icon token-info-icon" title="Armor Class: ' + ac + '"><i class="fas fa-shield-alt"></i> ' + ac + '</div><div class="control-icon token-info-icon" title="' + perceptionTitle + ': ' + perception + '"><i class="fas fa-eye"></i> ' + perception + '</div></div>');
+        let defaultButtons = '<div class="col token-info-column-' + position + '"><div class="control-icon token-info-icon">' + speed + '</div><div class="control-icon token-info-icon" title="Armor Class: ' + ac + '"><i class="fas fa-shield-alt"></i> ' + ac + '</div><div class="control-icon token-info-icon" title="Passive Perception: ' + perception + '"><i class="fas fa-eye"></i> ' + perception + '</div></div>'
+
+        let passiveSensesButtons = '';
+        if (!['pf2e', 'pf1'].includes(game.world.system) && game.settings.get(MODULE_NAME, ALL_PASSIVE_SENSES_MODULE_SETTING)) {
+            const investigation =  actor.data.data.skills.inv.passive;
+            const insight =  actor.data.data.skills.ins.passive;
+            const stealth =  actor.data.data.skills.ste.passive;
+
+            const passiveInvestigationButton = `<div class="control-icon token-info-icon" title="Passive Investigation: ${investigation}"><i class="fas fa-search"></i>${investigation}</div></div>`;
+            const passiveInsightButton = `<div class="control-icon token-info-icon" title="Passive Insight: ${insight}"><i class="fas fa-lightbulb"></i>${insight}</div></div>`;
+            const passiveStealthButton = `<div class="control-icon token-info-icon" title="Passive Stealth: ${stealth}"><i class="fas fa-eye-slash"></i>${stealth}</div></div>`;
+            passiveSensesButtons = `${passiveInvestigationButton}${passiveInsightButton}${passiveStealthButton}`;
+        }
+
+        let buttons = $(`${defaultButtons}${passiveSensesButtons}`);
 
         html.find('.col.left').wrap(newdiv);
         html.find('.col.left').before(buttons);
@@ -64,7 +78,7 @@ class TokenInfoIcons {
 }
 
 Hooks.on('ready', () => {
-    let gmOnly = game.settings.get("token-info-icons", "gmOnly");
+    const gmOnly = game.settings.get(MODULE_NAME, GMONLY_MODULE_SETTING);
 
     if (gmOnly) {
         if (game.user.isGM) {
@@ -80,7 +94,7 @@ Hooks.on('ready', () => {
 });
 
 Hooks.once("init", () => {
-    game.settings.register("token-info-icons", "gmOnly", {
+    game.settings.register(MODULE_NAME, GMONLY_MODULE_SETTING, {
         name: "GM only?",
         hint: "Show the token info to the GM only or to all players?",
         scope: "world",
@@ -89,9 +103,16 @@ Hooks.once("init", () => {
         type: Boolean
     });
 
-    const choices = new Array("Left", "Right");
+    game.settings.register(MODULE_NAME, ALL_PASSIVE_SENSES_MODULE_SETTING, {
+        name: 'Show all passive senses (dnd5e)',
+        hint: 'Show passive perception/investigation/insight/stealth instead of just passive perception',
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean
+    });
 
-    game.settings.register("token-info-icons", "position", {
+    game.settings.register(MODULE_NAME, POSITION_MODULE_SETTING, {
         name: "Token Position",
         hint: "Which side of the token should the info appear on?",
         scope: "world",

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -69,9 +69,9 @@ class TokenInfoIcons {
             const insight = actor.data.data.skills.ins.passive;
             const stealth = actor.data.data.skills.ste.passive;
 
-            const passiveInvestigationButton = `<div class="control-icon token-info-icon" title="Passive Investigation: ${investigation}"><i class="fas fa-search"></i>${investigation}</div></div>`;
-            const passiveInsightButton = `<div class="control-icon token-info-icon" title="Passive Insight: ${insight}"><i class="fas fa-lightbulb"></i>${insight}</div></div>`;
-            const passiveStealthButton = `<div class="control-icon token-info-icon" title="Passive Stealth: ${stealth}"><i class="fas fa-eye-slash"></i>${stealth}</div></div>`;
+            const passiveInvestigationButton = `<div class="control-icon token-info-icon" title="Passive Investigation: ${investigation}"><i class="fas fa-search"></i> ${investigation}</div></div>`;
+            const passiveInsightButton = `<div class="control-icon token-info-icon" title="Passive Insight: ${insight}"><i class="fas fa-lightbulb"></i> ${insight}</div></div>`;
+            const passiveStealthButton = `<div class="control-icon token-info-icon" title="Passive Stealth: ${stealth}"><i class="fas fa-eye-slash"></i> ${stealth}</div></div>`;
             passiveSensesButtons = `${passiveInvestigationButton}${passiveInsightButton}${passiveStealthButton}`;
         }
 

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -1,17 +1,14 @@
 class TokenInfoIcons {
-
-
     static async addTokenInfoButtons(app, html, data) {
-        
         let actor = canvas.tokens.get(data._id).actor;
         //let actor = game.actors.get(data.actorId);
         if (actor === undefined) return;
 
         let ac = 10
         if (game.world.system === "pf1") {
-          ac = actor.data.data.attributes.ac.normal.total
+            ac = actor.data.data.attributes.ac.normal.total
         } else {
-          ac = (isNaN(parseInt(actor.data.data.attributes.ac.value)) || parseInt(actor.data.data.attributes.ac.value) === 0) ? 10 : parseInt(actor.data.data.attributes.ac.value);
+            ac = (isNaN(parseInt(actor.data.data.attributes.ac.value)) || parseInt(actor.data.data.attributes.ac.value) === 0) ? 10 : parseInt(actor.data.data.attributes.ac.value);
         }
 
         let perceptionTitle = "Passive Perception";
@@ -64,7 +61,6 @@ class TokenInfoIcons {
         html.find('.col.left').wrap(newdiv);
         html.find('.col.left').before(buttons);
     }
-
 }
 
 Hooks.on('ready', () => {
@@ -72,39 +68,41 @@ Hooks.on('ready', () => {
 
     if (gmOnly) {
         if (game.user.isGM) {
-            Hooks.on('renderTokenHUD', (app, html, data) => { TokenInfoIcons.addTokenInfoButtons(app, html, data) });
+            Hooks.on('renderTokenHUD', (app, html, data) => {
+                TokenInfoIcons.addTokenInfoButtons(app, html, data)
+            });
         }
     } else {
-        Hooks.on('renderTokenHUD', (app, html, data) => { TokenInfoIcons.addTokenInfoButtons(app, html, data) });
+        Hooks.on('renderTokenHUD', (app, html, data) => {
+            TokenInfoIcons.addTokenInfoButtons(app, html, data)
+        });
     }
-    
-	
 });
 
 Hooks.once("init", () => {
-	game.settings.register("token-info-icons", "gmOnly", {
-		name: "GM only?",
-		hint: "Show the token info to the GM only or to all players?",
-		scope: "world",
-		config: true,
-		default: true,
-		type: Boolean
+    game.settings.register("token-info-icons", "gmOnly", {
+        name: "GM only?",
+        hint: "Show the token info to the GM only or to all players?",
+        scope: "world",
+        config: true,
+        default: true,
+        type: Boolean
     });
-    
+
     const choices = new Array("Left", "Right");
 
     game.settings.register("token-info-icons", "position", {
-		name: "Token Position",
-		hint: "Which side of the token should the info appear on?",
+        name: "Token Position",
+        hint: "Which side of the token should the info appear on?",
         scope: "world",
         config: true,
-		type: String,
+        type: String,
         default: "left",
         choices: {
             "left": "left",
             "right": "right",
         }
-	});
+    });
 });
 
 console.log("Token Info Icons loaded");

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -69,9 +69,9 @@ class TokenInfoIcons {
             const insight = actor.data.data.skills.ins.passive;
             const stealth = actor.data.data.skills.ste.passive;
 
-            const passiveInvestigationButton = `<div class="control-icon token-info-icon" title="Passive Investigation: ${investigation}"><i class="fas fa-search"></i> ${investigation}</div></div>`;
-            const passiveInsightButton = `<div class="control-icon token-info-icon" title="Passive Insight: ${insight}"><i class="fas fa-lightbulb"></i> ${insight}</div></div>`;
-            const passiveStealthButton = `<div class="control-icon token-info-icon" title="Passive Stealth: ${stealth}"><i class="fas fa-eye-slash"></i> ${stealth}</div></div>`;
+            const passiveInvestigationButton = `<div class="control-icon token-info-icon" title="Passive Investigation: ${investigation}"><i class="fas fa-search"></i> ${investigation}</div>`;
+            const passiveInsightButton = `<div class="control-icon token-info-icon" title="Passive Insight: ${insight}"><i class="fas fa-lightbulb"></i> ${insight}</div>`;
+            const passiveStealthButton = `<div class="control-icon token-info-icon" title="Passive Stealth: ${stealth}"><i class="fas fa-eye-slash"></i> ${stealth}</div>`;
             passiveSensesButtons = `${passiveInvestigationButton}${passiveInsightButton}${passiveStealthButton}`;
         }
 


### PR DESCRIPTION
This PR adds 3 more token info icons for passive senses that are regularly used, at least in my games:

- passive investigation
- passive insight
- passive stealth

A new setting is also available to hide/display these new icons, so that it is possible to keep the current display if one wants.

I also updated the compatibility metadata as I have tested successfully the module on FoundryVTT 0.7.8.

Thanks for the cool module 🙏 Hopefully you find this addition to be useful 😄 

<img width="440" alt="Screen Shot 2020-12-16 at 20 03 45" src="https://user-images.githubusercontent.com/3068511/102424742-d2155a80-3fd9-11eb-8e31-beb3a03f0725.png">
