### PR TITLE
Vehicles do not have skills

### DIFF
--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -28,7 +28,7 @@ class TokenInfoIcons {
         perceptionTitle = "Perception DC";
       }
        else {
-          perception = actor.data.data.skills?.prc?.passive || 0;
+          perception = actor.system.skills?.prc?.passive || 0;
       }
 
       //console.log("TokenInfoIcons", actor);

--- a/token-info-icons.js
+++ b/token-info-icons.js
@@ -28,7 +28,7 @@ class TokenInfoIcons {
         perceptionTitle = "Perception DC";
       }
        else {
-          perception = actor.data.data.skills.prc.passive;
+          perception = actor.data.data.skills?.prc?.passive || 0;
       }
 
       //console.log("TokenInfoIcons", actor);


### PR DESCRIPTION
This sets vehicle passive perception to 0 rather than throwing an error.